### PR TITLE
docs: consolidation strategy brainstorming

### DIFF
--- a/docs/brainstorming/consolidation-strategy.md
+++ b/docs/brainstorming/consolidation-strategy.md
@@ -4,272 +4,162 @@
 > **Date**: 2024-12-05
 > **Contributors**: Open to all
 
-## The Opportunity
+## Purpose
 
-**Neuroimaging support in HuggingFace is actively being built.** The `datasets` library has excellent support for text, images, and audio, and the community is now extending this to scientific imaging formats (NIfTI, DICOM, BIDS).
+This repository consolidates neuroimaging tools and pipelines for working with BIDS datasets and NIfTI files. The goal is to coordinate community efforts, avoid duplication, and build practical demos for stroke lesion analysis and related use cases.
 
-Several PRs have already been merged, with more in active review. This document outlines how we can consolidate our efforts under `neuroimaging-go-brrrr` to coordinate effectively and avoid duplication.
+## What We're Building
 
-## Current State of HuggingFace Neuroimaging Support
-
-### What's Already Merged (thanks to community contributions)
-
-| PR | Title | Status | Date |
-|----|-------|--------|------|
-| [#7815](https://github.com/huggingface/datasets/pull/7815) | Add Nifti support | MERGED | Oct 24, 2025 |
-| [#7853](https://github.com/huggingface/datasets/pull/7853) | Fix embed storage nifti | MERGED | Nov 6, 2025 |
-| [#7874](https://github.com/huggingface/datasets/pull/7874) | Nifti visualization support | MERGED | Nov 19, 2025 |
-| [#7878](https://github.com/huggingface/datasets/pull/7878) | Replace papaya with NiiVue | MERGED | Nov 21, 2025 |
-
-> **Note**: While NIfTI support is merged in the `datasets` library, the HuggingFace Hub dataset viewer may lag behind or require dataset regeneration to fully support the new feature type.
-
-### What's Currently In Review
-
-| PR | Title | Status | Author |
-|----|-------|--------|--------|
-| [#7886](https://github.com/huggingface/datasets/pull/7886) | **BIDS dataset loader** | OPEN | Community |
-| [#7892](https://github.com/huggingface/datasets/pull/7892) | Encode nifti correctly when uploading lazily | OPEN | @CloseChoice |
-| [#7885](https://github.com/huggingface/datasets/pull/7885) | Add visualization paragraph to nifti readme | OPEN | @CloseChoice |
-| [#7835](https://github.com/huggingface/datasets/pull/7835) | Add DICOM support | DRAFT | @CloseChoice |
-
-## The Two Pipelines
-
-We've been building two complementary pipelines:
+### The Two Pipelines
 
 ```text
 ┌──────────────────────────────────────────────────────────────────────────┐
 │                        PRODUCTION PIPELINE                               │
-│                        (Upload TO HuggingFace)                           │
+│                        (Upload datasets to Hub)                          │
 │                                                                          │
 │   OpenNeuro BIDS ──► Validate ──► Convert ──► push_to_hub() ──► HF Hub   │
 │                                                                          │
-│   Repos: arc-aphasia-bids, stroke-deepisles-demo                         │
+│   Tools: arc-aphasia-bids, stroke-deepisles-demo                         │
 └──────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
                          ┌───────────────────┐
                          │   HuggingFace Hub │
-                         │   (Nifti datasets)│
+                         │   (NIfTI datasets)│
                          └───────────────────┘
                                     │
                                     ▼
 ┌──────────────────────────────────────────────────────────────────────────┐
 │                       CONSUMPTION PIPELINE                               │
-│                       (Load FROM HuggingFace)                            │
+│                       (Load and visualize)                               │
 │                                                                          │
-│   load_dataset('bids') ──► Stream ──► Decode Nifti ──► NiiVue viz        │
+│   load_dataset() ──► Stream ──► Decode NIfTI ──► NiiVue visualization    │
 │                                                                          │
-│   PRs: #7886 (BIDS loader), #7815 (Nifti), #7874 (visualization)         │
+│   Tools: bids-neuroimaging Space, visualization notebooks                │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
-## Ecosystem Overview
+## Repository Structure
 
 ```text
-┌──────────────────────────────────────────────────────────────────────────┐
-│                     neuroimaging-go-brrrr                                │
-│                     ═══════════════════════                              │
-│                     CONSOLIDATION HUB                                    │
-│                                                                          │
-│  Purpose: Coordinate community efforts to accelerate HF neuroimaging     │
-│                                                                          │
-│  Current contents:                                                       │
-│  ├── scripts/                                                            │
-│  │   ├── download_ds004884.sh                                            │
-│  │   └── push_to_hub_ds004884_full.py                                    │
-│  ├── tools/                                                              │
-│  │   ├── arc-aphasia-bids/                                               │
-│  │   └── bids-neuroimaging/  (HF Space visualization)                    │
-│  └── README.md                                                           │
-└──────────────────────────────────────────────────────────────────────────┘
-                                    ▲
-                                    │ (consolidates)
-        ┌───────────────────────────┼───────────────────────────┐
-        │                           │                           │
-        ▼                           ▼                           ▼
-┌──────────────────┐  ┌──────────────────┐  ┌──────────────────────────┐
-│ arc-aphasia-bids │  │ stroke-deepisles │  │ huggingface/datasets     │
-│ (PRODUCTION)     │  │ -demo            │  │ (CONSUMPTION)            │
-│                  │  │                  │  │                          │
-│ • Upload ARC     │  │ • DeepISLES      │  │ • Pending PRs for        │
-│   to HF Hub      │  │   inference      │  │   BIDS loader, lazy      │
-│ • BIDS→HF        │  │ • Gradio UI      │  │   upload, DICOM          │
-│   conversion     │  │ • Full test      │  │ • Merged: Nifti,         │
-│ • Validation     │  │   suite          │  │   NiiVue viz             │
-└──────────────────┘  └──────────────────┘  └──────────────────────────┘
-                                │
-                                ▼
-                      ┌──────────────────┐
-                      │ DeepIsles        │
-                      │ (External Ref)   │
-                      │                  │
-                      │ • Nature 2025    │
-                      │ • Stroke lesion  │
-                      │   segmentation   │
-                      │ • Docker image   │
-                      └──────────────────┘
+neuroimaging-go-brrrr/
+├── scripts/
+│   ├── download_ds004884.sh
+│   ├── push_to_hub_ds004884_full.py
+│   └── visualization/
+│       ├── ArcAphasiaBids.ipynb
+│       └── ArcAphasiaBidsLoadData.ipynb
+├── tools/
+│   ├── arc-aphasia-bids/
+│   └── bids-neuroimaging-space/  (git submodule)
+├── docs/
+│   └── brainstorming/
+└── README.md
 ```
 
 ## Related Repositories
 
-| Repository | Type | Purpose | Link |
-|------------|------|---------|------|
-| neuroimaging-go-brrrr | Hub | Consolidation hub for neuroimaging tools | [GitHub](https://github.com/CloseChoice/neuroimaging-go-brrrr) |
-| arc-aphasia-bids | Production | Upload ARC dataset (ds004884) to HuggingFace Hub | [GitHub](https://github.com/The-Obstacle-Is-The-Way/arc-aphasia-bids) |
-| stroke-deepisles-demo | Production | DeepISLES inference demo with Gradio UI | [GitHub](https://github.com/The-Obstacle-Is-The-Way/stroke-deepisles-demo) |
-| huggingface/datasets | Consumption | Pending PRs for BIDS loader, lazy upload fixes | [PR #7886](https://github.com/huggingface/datasets/pull/7886) |
-| DeepIsles | Reference | State-of-the-art stroke lesion segmentation | [GitHub](https://github.com/ezequieldlrosa/DeepIsles) |
+| Repository | Purpose | Link |
+|------------|---------|------|
+| neuroimaging-go-brrrr | Consolidation hub for neuroimaging tools | [GitHub](https://github.com/CloseChoice/neuroimaging-go-brrrr) |
+| arc-aphasia-bids | Upload ARC dataset (ds004884) to Hub | [GitHub](https://github.com/The-Obstacle-Is-The-Way/arc-aphasia-bids) |
+| stroke-deepisles-demo | DeepISLES inference demo with Gradio UI | [GitHub](https://github.com/The-Obstacle-Is-The-Way/stroke-deepisles-demo) |
+| DeepIsles | Stroke lesion segmentation (Nature 2025) | [GitHub](https://github.com/ezequieldlrosa/DeepIsles) |
 
-## HuggingFace Resources
+## Live Demos & Datasets
 
 | Resource | Description | Link |
 |----------|-------------|------|
-| arc-aphasia-bids dataset | ARC dataset on HF Hub (293 GB, 902 sessions) | [HF Hub](https://huggingface.co/datasets/hugging-science/arc-aphasia-bids) |
-| bids-neuroimaging Space | NiiVue visualization demo | [HF Spaces](https://huggingface.co/spaces/TobiasPitters/bids-neuroimaging) |
+| arc-aphasia-bids | ARC dataset (293 GB, 902 sessions) | [HF Hub](https://huggingface.co/datasets/hugging-science/arc-aphasia-bids) |
+| bids-neuroimaging | NiiVue visualization demo | [HF Space](https://huggingface.co/spaces/TobiasPitters/bids-neuroimaging) |
 
-## Key Technical Components
+## Key Components
 
-### 1. BIDS Loader (Consumption - PR #7886)
+### 1. arc-aphasia-bids
 
-Native BIDS support for HuggingFace's `datasets` library:
-
-```python
-from datasets import load_dataset
-
-# Load any BIDS dataset with one line
-ds = load_dataset('bids', data_dir="path/to/bids/dataset", streaming=True)
-
-# Push to Hub
-ds.push_to_hub("org/dataset-name", num_shards={"train": 500})
-```
-
-Features:
-
-- Uses `pybids` for BIDS-compliant file discovery
-- `Nifti()` feature type for NIfTI file handling (already merged)
-- `Nifti1ImageWrapper._repr_html_()` for NiiVue visualization (already merged)
-- Streaming support for large datasets
-
-### 2. arc-aphasia-bids (Production)
-
-Custom pipeline for the Aphasia Recovery Cohort (ARC) dataset:
+Pipeline for the Aphasia Recovery Cohort (ARC) dataset:
 
 - Converts OpenNeuro ds004884 (BIDS) to HuggingFace Dataset format
 - Validation against the Scientific Data paper (230 subjects, 902 sessions)
 - Session-level sharding for memory efficiency
 
-### 3. stroke-deepisles-demo (Production + Inference)
+### 2. stroke-deepisles-demo
 
 End-to-end inference demo:
 
-- Loads BIDS/HF neuroimaging data
+- Loads BIDS neuroimaging data
 - Runs DeepISLES Docker container for stroke lesion segmentation
 - Gradio UI for interactive visualization
 - Comprehensive test suite (96 tests, 82% coverage)
 
+### 3. bids-neuroimaging Space
+
+Web-based visualization using NiiVue:
+
+- Interactive 3D brain viewer
+- Multiplanar views (axial, coronal, sagittal)
+- Sample data from ARC dataset
+
+## Candidate Datasets
+
+Beyond ARC, other datasets to consider:
+
+| Dataset | Size | Format | Use Case |
+|---------|------|--------|----------|
+| ATLAS v2.0 | 1,271 subjects | BIDS | Stroke lesion segmentation benchmark |
+| ds004889 | Acute stroke | BIDS | Acute stroke imaging |
+| AOMIC | 1,370 subjects | BIDS | Large-scale multimodal MRI |
+
 ## Consolidation Options
 
-### Option A: Modular Monorepo
+### Option A: Modular Structure (Current)
+
+Keep repositories separate, use `neuroimaging-go-brrrr` as coordination hub with git submodules:
+
+**Pros:**
+- Minimal migration effort
+- Repos remain independently maintainable
+- Clear separation of concerns
+- Git submodules link related tools
+
+**Cons:**
+- Coordination overhead
+- Cross-repo changes require multiple PRs
+
+### Option B: Monorepo
 
 Migrate all code into `neuroimaging-go-brrrr` as packages:
 
-```text
-neuroimaging-go-brrrr/
-├── packages/
-│   ├── arc-bids/              ← arc-aphasia-bids code
-│   ├── stroke-demo/           ← stroke-deepisles-demo code
-│   └── bids-loader-examples/  ← Examples using native BIDS loader
-├── scripts/
-├── tools/
-├── docs/
-└── pyproject.toml             ← Workspace configuration
-```
-
 **Pros:**
-
 - Single source of truth
 - Easier cross-package development
 - Unified CI/CD
 
 **Cons:**
-
-- Larger repository size (e.g., `bids-neuroimaging` Space has 400MB parquet file)
+- Larger repository size
+- LFS/size constraints (e.g., 400MB parquet files)
 - More complex release management
-- Migration effort required
-- LFS/size constraints make some assets unsuitable for GitHub
-
-### Option B: Hub with Linked Repositories
-
-Keep repositories separate, use `neuroimaging-go-brrrr` as documentation/coordination hub:
-
-```text
-neuroimaging-go-brrrr/
-├── docs/
-│   ├── architecture.md        ← How repos relate
-│   ├── getting-started.md     ← Quick start guide
-│   └── contributing.md        ← Contribution guidelines
-├── scripts/                   ← Shared utility scripts
-├── tools/                     ← Shared tools
-└── README.md                  ← Links to all repos
-```
-
-**Pros:**
-
-- Minimal migration effort
-- Repos remain independently maintainable
-- Clear separation of concerns
-
-**Cons:**
-
-- Coordination overhead
-- Potential for divergence
-- Cross-repo changes require multiple PRs
-
-### Option C: Focus on Upstream First
-
-Prioritize getting pending PRs merged into `huggingface/datasets`, then reassess:
-
-- Push [#7886](https://github.com/huggingface/datasets/pull/7886) (BIDS loader) to merge
-- Push [#7892](https://github.com/huggingface/datasets/pull/7892) (lazy upload fix) to merge
-- Once merged, `arc-aphasia-bids` simplifies to example usage
-- Focus consolidation on inference/demo tooling
-
-**Pros:**
-
-- Leverages official HuggingFace support
-- Reduces maintenance burden
-- Community benefits from upstream contribution
-
-**Cons:**
-
-- Dependent on upstream merge timeline
-- May need interim solutions
 
 ## Open Questions
 
-1. **How can we support the HuggingFace review process?** Should we coordinate via Hugging Science Discord to help with testing or provide additional context?
+1. **Additional datasets?** Should we prioritize ATLAS v2.0, ds004889, or others?
 
-2. **Monorepo vs. linked repos?** What structure best serves the community?
+2. **Demo deployment?** Should `stroke-deepisles-demo` be deployed as a HuggingFace Space?
 
-3. **Demo deployment?** Should `stroke-deepisles-demo` be deployed as a HuggingFace Space alongside `bids-neuroimaging`?
-
-4. **Additional datasets?** What other OpenNeuro datasets should be prioritized for HuggingFace upload?
-   - ds004889 (acute stroke) is mentioned in README.md
+3. **Monorepo vs. linked repos?** What structure best serves contributors?
 
 ## Next Steps
 
-- [ ] Coordinate via Hugging Science Discord to support PRs in review
 - [ ] Discuss consolidation approach in GitHub Issues
-- [ ] Decide on monorepo vs. linked repos structure
-- [ ] Create issues for specific integration tasks
-- [ ] Document contribution workflow for new collaborators
+- [ ] Add more visualization notebooks
+- [ ] Explore ATLAS v2.0 dataset integration
+- [ ] Document contribution workflow
 
 ## References
 
 - [OpenNeuro ds004884 (ARC)](https://openneuro.org/datasets/ds004884) - Aphasia Recovery Cohort
 - [OpenNeuro ds004889](https://openneuro.org/datasets/ds004889) - Acute stroke dataset
-- [DeepISLES Nature Paper](https://www.nature.com/articles/s41467-025-62373-x) - Stroke lesion segmentation
-- [ISLES'22 Challenge](https://isles22.grand-challenge.org/) - Ischemic Stroke Lesion Segmentation
-- [HuggingFace Datasets](https://huggingface.co/docs/datasets/) - Dataset library documentation
+- [ATLAS v2.0](https://atlas.grand-challenge.org/) - Stroke lesion benchmark
+- [DeepISLES Paper](https://www.nature.com/articles/s41467-025-62373-x) - Nature 2025
 - [BIDS Specification](https://bids-specification.readthedocs.io/) - Brain Imaging Data Structure
-- [Hugging Science Discord](https://discord.gg/huggingface) - Community coordination
+- [NiiVue](https://github.com/niivue/niivue) - Web-based neuroimaging viewer


### PR DESCRIPTION
## Summary

Adds a brainstorming document outlining how the Hugging Science community can consolidate neuroimaging efforts under `neuroimaging-go-brrrr`.

**The Problem**: HuggingFace has been slow to integrate neuroimaging/BIDS support. We're working together to accelerate this.

## What's in the doc

- Current state of HF neuroimaging PRs (merged vs pending)
- Production vs Consumption pipeline framing
- Three consolidation options for discussion
- Open questions for community input

## Key Links

- [BIDS Loader PR #7886](https://github.com/huggingface/datasets/pull/7886) (pending)
- [arc-aphasia-bids dataset](https://huggingface.co/datasets/hugging-science/arc-aphasia-bids)
- [bids-neuroimaging Space](https://huggingface.co/spaces/TobiasPitters/bids-neuroimaging)

## Open for Discussion

This is a brainstorming doc - feedback welcome on consolidation approach, missing context, or better options.