### PR TITLE
docs: add data directory READMEs for contributor guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-**/data/*
-
 # OS
 .DS_Store
 
@@ -18,8 +16,14 @@ htmlcov/
 # ============================================
 # Neuroimaging / BIDS / NIfTI specific
 # ============================================
-data/
-openneuro/
+# Ignore data contents but keep READMEs for contributor guidance
+data/**
+!data/
+!data/README.md
+!data/openneuro/
+!data/openneuro/README.md
+!data/zenodo/
+!data/zenodo/README.md
 ds*/
 *.nii
 *.nii.gz

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,19 @@
+# Data Directory
+
+This directory contains local copies of BIDS datasets for processing with bids-hub.
+
+## Structure
+
+```
+data/
+├── openneuro/          # OpenNeuro datasets
+│   └── ds004884/       # ARC Aphasia dataset
+└── zenodo/             # Zenodo datasets
+    └── isles24/        # ISLES 2024 stroke dataset
+```
+
+## Downloading Datasets
+
+See the README in each subdirectory for download instructions.
+
+**Note:** Dataset files (NIfTI, etc.) are git-ignored. Only these README files are tracked.

--- a/data/openneuro/README.md
+++ b/data/openneuro/README.md
@@ -1,0 +1,42 @@
+# OpenNeuro Datasets
+
+## ARC Aphasia Dataset (ds004884)
+
+The Aphasia Recovery Cohort (ARC) dataset contains multimodal MRI data from 230 chronic stroke patients with aphasia.
+
+### Download
+
+```bash
+# Using OpenNeuro CLI (recommended)
+openneuro download --snapshot 1.0.1 ds004884 ds004884
+
+# Or using DataLad
+datalad install https://github.com/OpenNeuroDatasets/ds004884.git
+cd ds004884
+datalad get .
+```
+
+### Expected Structure
+
+```
+ds004884/
+├── participants.tsv
+├── sub-M2001/
+│   └── ses-*/
+│       ├── anat/       # T1w, T2w, FLAIR
+│       ├── func/       # BOLD fMRI
+│       └── dwi/        # Diffusion imaging
+└── derivatives/
+    └── lesion_masks/   # Expert lesion segmentations
+```
+
+### Validate Download
+
+```bash
+uv run bids-hub arc validate data/openneuro/ds004884
+```
+
+### Reference
+
+- Paper: [Gibson et al., Scientific Data 2024](https://doi.org/10.1038/s41597-024-03819-7)
+- OpenNeuro: https://openneuro.org/datasets/ds004884

--- a/data/zenodo/README.md
+++ b/data/zenodo/README.md
@@ -1,0 +1,45 @@
+# Zenodo Datasets
+
+## ISLES 2024 Stroke Dataset
+
+The ISLES 2024 challenge dataset contains multimodal acute stroke imaging (CT/MRI) from 149 subjects.
+
+### Download
+
+```bash
+# Download from Zenodo (requires registration)
+# https://zenodo.org/records/17652035
+
+# Extract to this directory
+unzip ISLES24_Training.zip -d isles24
+```
+
+### Expected Structure
+
+```
+isles24/
+└── train/
+    ├── rawdata/
+    │   └── sub-strokeXXXX/
+    │       ├── ses-01/         # Acute imaging
+    │       │   └── ct/         # NCCT, CTA, CTP, perfusion maps
+    │       └── ses-02/         # Follow-up MRI
+    │           └── dwi/        # DWI, ADC
+    ├── derivatives/
+    │   └── sub-strokeXXXX/
+    │       └── ses-02/
+    │           └── anat/       # Lesion masks
+    └── phenotype/
+        └── phenotype.xlsx      # Clinical metadata
+```
+
+### Validate Download
+
+```bash
+uv run bids-hub isles24 validate data/zenodo/isles24/train
+```
+
+### Reference
+
+- Challenge: https://isles-24.grand-challenge.org/
+- Zenodo: https://zenodo.org/records/17652035


### PR DESCRIPTION
## Summary

- Add `data/README.md` explaining folder structure
- Add `data/openneuro/README.md` with ARC download instructions
- Add `data/zenodo/README.md` with ISLES24 download instructions
- Update `.gitignore` to track READMEs while ignoring actual data files

## Why

Contributors cloning the repo need to know:
1. Where to put datasets (`data/openneuro/`, `data/zenodo/`)
2. How to download them (OpenNeuro CLI, DataLad, Zenodo)
3. Expected directory structure for validation

## Test plan

- [x] READMEs are tracked by git
- [x] Data files (*.nii.gz, etc.) are still ignored
- [x] `git check-ignore` confirms correct behavior