### PR TITLE
feat: add AOMIC-PIOP1 dataset support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 .mypy_cache/
 .ruff_cache/
 .coverage
+coverage.xml
 htmlcov/
 
 # ============================================
@@ -32,3 +33,7 @@ ds*/
 
 # HuggingFace cache
 .cache/huggingface/
+
+# Claude Code infrastructure (local configuration)
+.claude/
+dev/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Purpose
 
-This package uploads BIDS neuroimaging datasets (ARC, ISLES24) to HuggingFace Hub. It converts BIDS-formatted NIfTI files to HuggingFace's `Dataset` format with proper `Nifti()` feature types.
+This package uploads BIDS neuroimaging datasets (ARC, AOMIC-PIOP1, ISLES24) to HuggingFace Hub. It converts BIDS-formatted NIfTI files to HuggingFace's `Dataset` format with proper `Nifti()` feature types.
 
 ## Commands
 
@@ -39,6 +39,12 @@ uv run bids-hub isles24 validate data/zenodo/isles24/train
 uv run bids-hub isles24 build data/zenodo/isles24/train --dry-run
 uv run bids-hub isles24 build data/zenodo/isles24/train --no-dry-run
 uv run bids-hub isles24 info
+
+# AOMIC-PIOP1 commands
+uv run bids-hub aomic piop1 validate data/openneuro/ds002785
+uv run bids-hub aomic piop1 build data/openneuro/ds002785 --dry-run
+uv run bids-hub aomic piop1 build data/openneuro/ds002785 --no-dry-run
+uv run bids-hub aomic piop1 info
 ```
 
 ## Architecture
@@ -65,9 +71,11 @@ HuggingFace Hub
 | `core/builder.py` | Generic BIDS→HF conversion (build_hf_dataset, push_dataset_to_hub) |
 | `core/config.py` | DatasetBuilderConfig dataclass |
 | `core/utils.py` | File discovery helpers (find_single_nifti, find_all_niftis) |
+| `datasets/aomic_piop1.py` | AOMIC-PIOP1 schema, file discovery, pipeline |
 | `datasets/arc.py` | ARC schema, file discovery, pipeline |
 | `datasets/isles24.py` | ISLES24 schema, file discovery, pipeline |
 | `validation/base.py` | Generic validation framework |
+| `validation/aomic.py` | AOMIC validation rules |
 | `validation/arc.py` | ARC validation rules |
 | `validation/isles24.py` | ISLES24 validation rules |
 | `cli.py` | Typer CLI with subcommands |
@@ -124,9 +132,23 @@ Features({
 })
 ```
 
+### AOMIC-PIOP1 Schema (one row per SUBJECT, flattened)
+
+```python
+Features({
+    "subject_id": Value("string"),    # e.g., "sub-0001"
+    "t1w": Nifti(),                   # T1-weighted structural (single)
+    "dwi": Sequence(Nifti()),         # Diffusion-weighted (multiple runs)
+    "bold": Sequence(Nifti()),        # fMRI time-series (all tasks)
+    "age": Value("float32"),
+    "sex": Value("string"),
+    "handedness": Value("string"),
+})
+```
+
 ## Testing
 
-Tests use synthetic BIDS structures with minimal NIfTI files (2x2x2 voxels). The fixtures `synthetic_bids_root` (ARC) and `synthetic_isles24_root` (ISLES24) create complete datasets with all modalities for comprehensive coverage.
+Tests use synthetic BIDS structures with minimal NIfTI files (2x2x2 voxels). The fixtures `synthetic_bids_root` (ARC), `synthetic_aomic_piop1_bids_root` (AOMIC-PIOP1), and `synthetic_isles24_root` (ISLES24) create complete datasets with all modalities for comprehensive coverage.
 
 Key test patterns:
 - `_create_minimal_nifti()`: Creates valid NIfTI files quickly

--- a/docs/dataset-cards/aomic-piop1.md
+++ b/docs/dataset-cards/aomic-piop1.md
@@ -1,0 +1,73 @@
+---
+license: cc0-1.0
+task_categories:
+  - image-classification
+tags:
+  - medical
+  - neuroimaging
+  - brain
+  - healthy-subjects
+  - MRI
+  - fMRI
+  - DWI
+  - BIDS
+  - AOMIC
+  - OpenNeuro
+size_categories:
+  - 100K<n<1M
+---
+
+# AOMIC-PIOP1 Dataset
+
+Amsterdam Open MRI Collection - Population Imaging of Psychology Dataset 1 (PIOP1).
+
+## Dataset Description
+
+- **Source:** [OpenNeuro ds002785](https://openneuro.org/datasets/ds002785)
+- **Paper:** [Snoek et al., Scientific Data 2021](https://doi.org/10.1038/s41597-021-00870-6)
+- **License:** CC0 (Public Domain)
+- **Subjects:** 216 healthy young adults (after quality control)
+
+## Dataset Structure
+
+| Modality | Count | Description |
+|----------|-------|-------------|
+| T1w | 216 | T1-weighted structural MRI |
+| DWI | 216 | Diffusion-weighted imaging (multiple runs) |
+| BOLD | 216 | Functional MRI (resting-state + tasks) |
+
+**Note:** All 216 subjects have complete multimodal data (T1w, DWI, and BOLD scans).
+
+## Usage
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("hugging-science/aomic-piop1", split="train")
+
+# Access a subject
+example = ds[0]
+print(example["subject_id"])  # "sub-0001"
+print(example["t1w"])         # NIfTI array (T1-weighted structural)
+print(example["dwi"])          # List of NIfTI arrays (multiple runs)
+print(example["bold"])         # List of NIfTI arrays (multiple tasks)
+print(example["age"])          # Age in years
+print(example["sex"])          # Sex (M/F)
+print(example["handedness"])   # Handedness (L/R)
+```
+
+## Citation
+
+```bibtex
+@article{snoek2021amsterdam,
+  title={The Amsterdam Open MRI Collection, a set of multimodal MRI datasets for individual difference analyses},
+  author={Snoek, Lukas and van der Miesen, Maite M and Beemsterboer, Thijs and Van Der Leij, Andries and Eigenhuis, Annemarie and Steven Scholte, H},
+  journal={Scientific Data},
+  volume={8},
+  number={1},
+  pages={85},
+  year={2021},
+  publisher={Nature Publishing Group},
+  doi={10.1038/s41597-021-00870-6}
+}
+```

--- a/scripts/download_aomic_piop1.sh
+++ b/scripts/download_aomic_piop1.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Download AOMIC-PIOP1 from OpenNeuro
+# Dataset: ds002785 (Amsterdam Open MRI Collection - PIOP1)
+# License: CC0 (Public Domain)
+# Subjects: 216 healthy adults
+# =============================================================================
+set -euo pipefail
+
+DATASET_ID="ds002785"
+TARGET_DIR="${1:-data/openneuro/ds002785}"
+
+echo "=============================================="
+echo "AOMIC-PIOP1 Dataset Download Script"
+echo "Dataset: OpenNeuro $DATASET_ID"
+echo "Target:  $TARGET_DIR"
+echo "Subjects: 216 healthy adults"
+echo "=============================================="
+
+# Check if target directory already has data
+if [ -d "$TARGET_DIR" ] && [ "$(ls -A "$TARGET_DIR" 2>/dev/null)" ]; then
+    echo ""
+    echo "WARNING: Target directory already contains files."
+    echo "         Delete or rename it to re-download."
+    echo ""
+    read -p "Continue anyway? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Aborted."
+        exit 1
+    fi
+fi
+
+# Create target directory
+mkdir -p "$TARGET_DIR"
+
+# =============================================================================
+# METHOD 1: AWS S3 (Recommended - No authentication required)
+# =============================================================================
+download_via_s3() {
+    echo ""
+    echo "Downloading via AWS S3 (no authentication required)..."
+    echo "This downloads the latest snapshot."
+    echo ""
+
+    if ! command -v aws &> /dev/null; then
+        echo "ERROR: AWS CLI not found."
+        echo ""
+        echo "Install with:"
+        echo "  macOS:  brew install awscli"
+        echo "  Linux:  pip install awscli"
+        echo "  Or:     https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+        echo ""
+        return 1
+    fi
+
+    echo "Starting download (this may take a while for large datasets)..."
+    echo "Command: aws s3 sync --no-sign-request s3://openneuro.org/$DATASET_ID $TARGET_DIR"
+    echo ""
+
+    aws s3 sync --no-sign-request "s3://openneuro.org/$DATASET_ID" "$TARGET_DIR"
+
+    echo ""
+    echo "Download complete!"
+    return 0
+}
+
+# =============================================================================
+# METHOD 2: OpenNeuro CLI (Deno-based, requires API key)
+# =============================================================================
+download_via_openneuro_cli() {
+    echo ""
+    echo "Downloading via OpenNeuro CLI..."
+    echo ""
+
+    if ! command -v openneuro &> /dev/null; then
+        echo "ERROR: OpenNeuro CLI not found."
+        echo ""
+        echo "Install with Deno (npm version is deprecated):"
+        echo "  1. Install Deno: curl -fsSL https://deno.land/install.sh | sh"
+        echo "  2. Install CLI:  deno install -A --global jsr:@openneuro/cli -n openneuro"
+        echo "  3. Login:        openneuro login  # requires API key from openneuro.org"
+        echo ""
+        return 1
+    fi
+
+    echo "Starting download..."
+    echo "Command: openneuro download $DATASET_ID $TARGET_DIR"
+    echo ""
+    echo "NOTE: This creates a DataLad dataset. Large files are annexed."
+    echo "      Use 'git-annex get <path>' or 'datalad get <path>' to download annexed files."
+    echo ""
+
+    openneuro download "$DATASET_ID" "$TARGET_DIR"
+
+    echo ""
+    echo "Download complete!"
+    return 0
+}
+
+# =============================================================================
+# METHOD 3: Subset download (for testing)
+# =============================================================================
+download_subset_s3() {
+    echo ""
+    echo "Downloading SUBSET via AWS S3 (for testing)..."
+    echo "This downloads only root files + first 3 subjects."
+    echo ""
+
+    if ! command -v aws &> /dev/null; then
+        echo "ERROR: AWS CLI not found."
+        return 1
+    fi
+
+    # Download root-level files (participants.tsv, dataset_description.json, etc.)
+    echo "Downloading root files..."
+    aws s3 sync --no-sign-request \
+        --exclude "*" \
+        --include "*.tsv" \
+        --include "*.json" \
+        --include "*.txt" \
+        --include "README*" \
+        "s3://openneuro.org/$DATASET_ID" "$TARGET_DIR"
+
+    # Download first 3 subjects
+    echo "Downloading first 3 subjects..."
+    for i in 1 2 3; do
+        # List subjects and get the i-th one
+        SUBJECT=$(aws s3 ls --no-sign-request "s3://openneuro.org/$DATASET_ID/" | grep "sub-" | head -n $i | tail -n 1 | awk '{print $2}' | tr -d '/')
+        if [ -n "$SUBJECT" ]; then
+            echo "  Downloading $SUBJECT..."
+            aws s3 sync --no-sign-request \
+                "s3://openneuro.org/$DATASET_ID/$SUBJECT" "$TARGET_DIR/$SUBJECT"
+        fi
+    done
+
+    echo ""
+    echo "Subset download complete!"
+    return 0
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+echo ""
+echo "Select download method:"
+echo "  1) AWS S3 - Full dataset (recommended, no auth, ~216 subjects)"
+echo "  2) AWS S3 - Subset only (for testing, ~3 subjects)"
+echo "  3) OpenNeuro CLI (requires Deno + API key)"
+echo ""
+read -p "Enter choice [1-3]: " choice
+
+case $choice in
+    1) download_via_s3 ;;
+    2) download_subset_s3 ;;
+    3) download_via_openneuro_cli ;;
+    *) echo "Invalid choice. Exiting."; exit 1 ;;
+esac
+
+echo ""
+echo "=============================================="
+echo "Next steps:"
+echo "  1. Validate the download:"
+echo "     uv run bids-hub aomic piop1 validate $TARGET_DIR"
+echo ""
+echo "  2. Inspect the BIDS structure:"
+echo "     ls -la $TARGET_DIR"
+echo "     cat $TARGET_DIR/participants.tsv | head"
+echo ""
+echo "  3. Check dataset size:"
+echo "     du -sh $TARGET_DIR"
+echo ""
+echo "  4. Build the HuggingFace dataset:"
+echo "     uv run bids-hub aomic piop1 build $TARGET_DIR --dry-run"
+echo ""
+echo "  5. Get dataset info:"
+echo "     uv run bids-hub aomic piop1 info"
+echo "=============================================="

--- a/src/bids_hub/__init__.py
+++ b/src/bids_hub/__init__.py
@@ -7,10 +7,13 @@ from .core import DatasetBuilderConfig, build_hf_dataset, push_dataset_to_hub
 
 # Datasets
 from .datasets import (
+    build_and_push_aomic_piop1,
     build_and_push_arc,
     build_and_push_isles24,
+    build_aomic_piop1_file_table,
     build_arc_file_table,
     build_isles24_file_table,
+    get_aomic_piop1_features,
     get_arc_features,
     get_isles24_features,
 )
@@ -18,6 +21,7 @@ from .datasets import (
 # Validation
 from .validation import (
     ValidationResult,
+    validate_aomic_piop1_download,
     validate_arc_download,
     validate_isles24_download,
 )
@@ -28,14 +32,18 @@ __all__ = [
     "DatasetBuilderConfig",
     "ValidationResult",
     "__version__",
+    "build_and_push_aomic_piop1",
     "build_and_push_arc",
     "build_and_push_isles24",
+    "build_aomic_piop1_file_table",
     "build_arc_file_table",
     "build_hf_dataset",
     "build_isles24_file_table",
+    "get_aomic_piop1_features",
     "get_arc_features",
     "get_isles24_features",
     "push_dataset_to_hub",
+    "validate_aomic_piop1_download",
     "validate_arc_download",
     "validate_isles24_download",
 ]

--- a/src/bids_hub/cli.py
+++ b/src/bids_hub/cli.py
@@ -26,9 +26,14 @@ from pathlib import Path
 import typer
 
 from .core import DatasetBuilderConfig
+from .datasets.aomic_piop1 import build_and_push_aomic_piop1
 from .datasets.arc import build_and_push_arc
 from .datasets.isles24 import build_and_push_isles24
-from .validation import validate_arc_download, validate_isles24_download
+from .validation import (
+    validate_aomic_piop1_download,
+    validate_arc_download,
+    validate_isles24_download,
+)
 
 app = typer.Typer(
     name="bids-hub",
@@ -48,14 +53,27 @@ app.add_typer(arc_app, name="arc")
 isles_app = typer.Typer(help="Commands for the ISLES'24 dataset.")
 app.add_typer(isles_app, name="isles24")
 
+# --- AOMIC Subcommand Group ---
+aomic_app = typer.Typer(
+    help="AOMIC (Amsterdam Open MRI Collection) dataset commands.\n\n"
+    "Source: OpenNeuro\n"
+    "License: CC0 (Public Domain)"
+)
+app.add_typer(aomic_app, name="aomic")
+
+# --- AOMIC-PIOP1 Sub-subcommand ---
+piop1_app = typer.Typer(help="AOMIC-PIOP1 dataset (ds002785, 216 subjects).")
+aomic_app.add_typer(piop1_app, name="piop1")
+
 
 # --- Global Commands ---
 @app.command("list")
 def list_datasets() -> None:
     """List all supported datasets."""
     typer.echo("Supported datasets:")
-    typer.echo("  arc     - Aphasia Recovery Cohort (OpenNeuro ds004884)")
-    typer.echo("  isles24 - ISLES 2024 Stroke (Zenodo)")
+    typer.echo("  arc         - Aphasia Recovery Cohort (OpenNeuro ds004884)")
+    typer.echo("  isles24     - ISLES 2024 Stroke (Zenodo)")
+    typer.echo("  aomic piop1 - AOMIC-PIOP1 (OpenNeuro ds002785)")
 
 
 # --- ARC Commands ---
@@ -282,6 +300,126 @@ def info_isles() -> None:
     typer.echo("  - Acute: NCCT, CTA, CTP")
     typer.echo("  - Follow-up: DWI, ADC")
     typer.echo("  - Lesion Segmentation Masks")
+
+
+# --- AOMIC-PIOP1 Commands ---
+@piop1_app.command("build")
+def build_aomic_piop1(
+    bids_root: Path = typer.Argument(
+        ...,
+        help="Path to AOMIC-PIOP1 BIDS root directory (ds002785).",
+        exists=False,
+    ),
+    hf_repo: str = typer.Option(
+        "hugging-science/aomic-piop1",
+        "--hf-repo",
+        "-r",
+        help="HuggingFace dataset repo ID.",
+    ),
+    dry_run: bool = typer.Option(
+        True,
+        "--dry-run/--no-dry-run",
+        help="If true (default), build dataset but do not push to Hub.",
+    ),
+) -> None:
+    """
+    Build (and optionally push) the AOMIC-PIOP1 HF dataset.
+    """
+    config = DatasetBuilderConfig(
+        bids_root=bids_root,
+        hf_repo_id=hf_repo,
+        dry_run=dry_run,
+    )
+
+    typer.echo(f"Processing AOMIC-PIOP1 dataset from: {bids_root}")
+    typer.echo(f"Target HF repo: {hf_repo}")
+    typer.echo(f"Dry run: {dry_run}")
+
+    build_and_push_aomic_piop1(config)
+
+    if dry_run:
+        typer.echo("Dry run complete. Dataset built but not pushed.")
+    else:
+        typer.echo(f"Dataset pushed to: https://huggingface.co/datasets/{hf_repo}")
+
+
+@piop1_app.command("validate")
+def validate_aomic_piop1(
+    bids_root: Path = typer.Argument(
+        ...,
+        help="Path to AOMIC-PIOP1 BIDS root directory (ds002785).",
+    ),
+    run_bids_validator: bool = typer.Option(
+        False,
+        "--bids-validator/--no-bids-validator",
+        help="Run external BIDS validator (requires npx, slow on large datasets).",
+    ),
+    sample_size: int = typer.Option(
+        10,
+        "--sample-size",
+        "-n",
+        help="Number of NIfTI files to spot-check for integrity.",
+    ),
+    tolerance: float = typer.Option(
+        0.0,
+        "--tolerance",
+        "-t",
+        min=0.0,
+        max=1.0,
+        help="Allowed fraction of missing files (0.0 to 1.0). Default 0.0 (strict).",
+    ),
+) -> None:
+    """
+    Validate an AOMIC-PIOP1 dataset download before pushing to HuggingFace.
+
+    Checks:
+    - Required BIDS files exist (dataset_description.json, participants.tsv)
+    - Subject count matches expected (216 from Sci Data paper)
+    - Modality counts match expected (T1w: 216, DWI: 216, BOLD: 216)
+    - Sample NIfTI files are loadable with nibabel
+    - (Optional) External BIDS validator passes
+
+    Run this after downloading to ensure data integrity before HF push.
+
+    Example:
+        bids-hub aomic piop1 validate data/openneuro/ds002785
+    """
+    result = validate_aomic_piop1_download(
+        bids_root,
+        run_bids_validator=run_bids_validator,
+        nifti_sample_size=sample_size,
+        tolerance=tolerance,
+    )
+
+    typer.echo(result.summary())
+
+    if not result.all_passed:
+        raise typer.Exit(code=1)
+
+
+@piop1_app.command("info")
+def info_aomic_piop1() -> None:
+    """
+    Show information about the AOMIC-PIOP1 dataset.
+    """
+    typer.echo("AOMIC-PIOP1 (Population Imaging of Psychology 1)")
+    typer.echo("=" * 40)
+    typer.echo("OpenNeuro ID: ds002785")
+    typer.echo("URL: https://openneuro.org/datasets/ds002785")
+    typer.echo("License: CC0 (Public Domain)")
+    typer.echo("")
+    typer.echo("Contains:")
+    typer.echo("  - 216 healthy adult subjects")
+    typer.echo("  - T1-weighted structural MRI")
+    typer.echo("  - Diffusion-weighted imaging (DWI)")
+    typer.echo("  - BOLD fMRI (resting-state + tasks)")
+    typer.echo("  - Demographics and psychometric data")
+    typer.echo("")
+    typer.echo("Expected counts (from Sci Data paper):")
+    typer.echo("  - Subjects: 216")
+    typer.echo("  - T1w: 216")
+    typer.echo("  - DWI: 216")
+    typer.echo("  - BOLD: 216")
 
 
 if __name__ == "__main__":

--- a/src/bids_hub/datasets/__init__.py
+++ b/src/bids_hub/datasets/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from .aomic_piop1 import (
+    build_and_push_aomic_piop1,
+    build_aomic_piop1_file_table,
+    get_aomic_piop1_features,
+)
 from .arc import build_and_push_arc, build_arc_file_table, get_arc_features
 from .isles24 import (
     build_and_push_isles24,
@@ -10,10 +15,13 @@ from .isles24 import (
 )
 
 __all__ = [
+    "build_and_push_aomic_piop1",
     "build_and_push_arc",
     "build_and_push_isles24",
+    "build_aomic_piop1_file_table",
     "build_arc_file_table",
     "build_isles24_file_table",
+    "get_aomic_piop1_features",
     "get_arc_features",
     "get_isles24_features",
 ]

--- a/src/bids_hub/datasets/aomic_piop1.py
+++ b/src/bids_hub/datasets/aomic_piop1.py
@@ -1,0 +1,192 @@
+"""
+AOMIC-PIOP1 (Amsterdam Open MRI Collection - PIOP1) dataset module.
+
+This module converts the AOMIC-PIOP1 BIDS dataset (OpenNeuro ds002785) into a
+Hugging Face Dataset.
+
+Dataset info:
+- OpenNeuro ID: ds002785
+- Description: Multimodal MRI from 216 healthy adults (university students)
+- License: CC0 (Public Domain)
+- URL: https://openneuro.org/datasets/ds002785
+- Paper: https://www.nature.com/articles/s41597-021-00870-6
+
+The AOMIC-PIOP1 dataset contains:
+- 216 healthy adult subjects
+- T1-weighted structural MRI scans
+- Diffusion-weighted imaging (multiple runs per subject)
+- BOLD fMRI scans (resting-state + multiple tasks)
+- Demographics and psychometric data (age, sex, handedness, personality scores)
+
+Schema: One row per SUBJECT (no longitudinal sessions in PIOP1)
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+from datasets import Features, Nifti, Sequence, Value
+
+from ..core import DatasetBuilderConfig, build_hf_dataset, push_dataset_to_hub
+from ..core.utils import find_all_niftis, find_single_nifti
+
+logger = logging.getLogger(__name__)
+
+
+def build_aomic_piop1_file_table(bids_root: Path) -> pd.DataFrame:
+    """
+    Build a file table for the AOMIC-PIOP1 dataset.
+
+    Walks the BIDS directory structure and builds a pandas DataFrame with
+    one row per SUBJECT containing paths to imaging data and metadata.
+
+    The function:
+    1. Reads participants.tsv for demographics (age, sex, handedness)
+    2. For each subject, finds ALL modalities:
+       - T1w: Single T1-weighted structural scan
+       - DWI: Multiple diffusion-weighted runs (list)
+       - BOLD: Multiple fMRI runs (resting-state + tasks, list)
+    3. Returns DataFrame with columns: subject_id, t1w, dwi, bold, age, sex, handedness
+
+    Args:
+        bids_root: Path to BIDS dataset root (should contain participants.tsv)
+
+    Returns:
+        DataFrame with one row per subject, columns for all modalities and metadata.
+        Missing modalities are represented as None (single) or [] (sequence).
+
+    Raises:
+        FileNotFoundError: If bids_root doesn't exist or participants.tsv is missing
+    """
+    # Validate inputs
+    bids_root = Path(bids_root)
+    if not bids_root.exists():
+        raise FileNotFoundError(f"BIDS root not found: {bids_root}")
+
+    participants_tsv = bids_root / "participants.tsv"
+    if not participants_tsv.exists():
+        raise FileNotFoundError(f"participants.tsv not found: {participants_tsv}")
+
+    # Read participants metadata
+    logger.info("Reading participants.tsv from %s", participants_tsv)
+    participants = pd.read_csv(participants_tsv, sep="\t")
+    logger.info("Found %d subjects in participants.tsv", len(participants))
+
+    # Initialize list to collect rows
+    rows = []
+
+    # Iterate over each subject in participants.tsv
+    for _, row in participants.iterrows():
+        subject_id = row["participant_id"]
+        subject_dir = bids_root / subject_id
+
+        # Skip if subject directory doesn't exist
+        if not subject_dir.exists():
+            logger.warning("Subject directory not found: %s (skipping)", subject_dir)
+            continue
+
+        logger.debug("Processing subject: %s", subject_id)
+
+        # Find T1w (single structural scan)
+        anat_dir = subject_dir / "anat"
+        t1w_path = find_single_nifti(anat_dir, f"{subject_id}_T1w.nii.gz")
+
+        # Find DWI (multiple runs possible)
+        dwi_dir = subject_dir / "dwi"
+        dwi_paths = find_all_niftis(dwi_dir, f"{subject_id}_*_dwi.nii.gz")
+
+        # Find BOLD (all fMRI runs: resting-state + tasks)
+        func_dir = subject_dir / "func"
+        bold_paths = find_all_niftis(func_dir, f"{subject_id}_*_bold.nii.gz")
+
+        # Extract metadata from participants.tsv
+        age = float(row["age"]) if pd.notna(row.get("age")) else None
+        sex = str(row["sex"]) if pd.notna(row.get("sex")) else None
+        handedness = str(row["handedness"]) if pd.notna(row.get("handedness")) else None
+
+        # Build row dictionary
+        row_dict = {
+            "subject_id": subject_id,
+            "t1w": t1w_path,
+            "dwi": dwi_paths,
+            "bold": bold_paths,
+            "age": age,
+            "sex": sex,
+            "handedness": handedness,
+        }
+
+        rows.append(row_dict)
+
+    # Create DataFrame from collected rows
+    file_table = pd.DataFrame(rows)
+    logger.info("Built file table with %d subjects", len(file_table))
+
+    return file_table
+
+
+def get_aomic_piop1_features() -> Features:
+    """
+    Get HuggingFace Features schema for AOMIC-PIOP1 dataset.
+
+    Returns:
+        Features object defining the schema with:
+        - subject_id: String identifier
+        - t1w: Single NIfTI structural scan
+        - dwi: Sequence of NIfTI diffusion scans
+        - bold: Sequence of NIfTI fMRI scans (all tasks)
+        - age: Float (years)
+        - sex: String (M/F)
+        - handedness: String (left/right/ambidextrous)
+    """
+    return Features(
+        {
+            "subject_id": Value("string"),
+            "t1w": Nifti(),
+            "dwi": Sequence(Nifti()),
+            "bold": Sequence(Nifti()),
+            "age": Value("float32"),
+            "sex": Value("string"),
+            "handedness": Value("string"),
+        }
+    )
+
+
+def build_and_push_aomic_piop1(config: DatasetBuilderConfig) -> None:
+    """
+    Build and optionally push AOMIC-PIOP1 dataset to HuggingFace Hub.
+
+    This function orchestrates the full pipeline:
+    1. Build file table from BIDS directory
+    2. Get Features schema
+    3. Build HuggingFace Dataset
+    4. Push to Hub (if not dry-run)
+
+    Args:
+        config: Configuration containing bids_root, hf_repo_id, dry_run flag
+
+    Raises:
+        FileNotFoundError: If BIDS root or participants.tsv missing
+    """
+    logger.info("Building AOMIC-PIOP1 dataset from %s", config.bids_root)
+
+    # Build file table
+    file_table = build_aomic_piop1_file_table(config.bids_root)
+
+    # Get schema
+    features = get_aomic_piop1_features()
+
+    # Build HuggingFace Dataset
+    logger.info("Converting to HuggingFace Dataset format...")
+    ds = build_hf_dataset(config, file_table, features)
+
+    # Push to Hub if not dry-run
+    if not config.dry_run:
+        logger.info("Pushing dataset to HuggingFace Hub: %s", config.hf_repo_id)
+        # Use num_shards = number of subjects to prevent OOM
+        num_shards = len(file_table)
+        push_dataset_to_hub(ds, config, num_shards=num_shards)
+        logger.info("✓ Dataset successfully pushed to %s", config.hf_repo_id)
+    else:
+        logger.info("Dry run - skipping push to Hub")

--- a/src/bids_hub/validation/__init__.py
+++ b/src/bids_hub/validation/__init__.py
@@ -1,5 +1,9 @@
 """Validation module - re-exports for backward compatibility."""
 
+from .aomic import (
+    AOMIC_PIOP1_VALIDATION_CONFIG,
+    validate_aomic_piop1_download,
+)
 from .arc import (
     ARC_VALIDATION_CONFIG,
     EXPECTED_COUNTS,  # Backward compat
@@ -24,6 +28,7 @@ from .isles24 import (
 )
 
 __all__ = [
+    "AOMIC_PIOP1_VALIDATION_CONFIG",
     "ARC_VALIDATION_CONFIG",
     "EXPECTED_COUNTS",
     "ISLES24_ARCHIVE_MD5",
@@ -35,6 +40,7 @@ __all__ = [
     "check_count",
     "check_phenotype_readable",
     "check_zero_byte_files",
+    "validate_aomic_piop1_download",
     "validate_arc_download",
     "validate_dataset",
     "validate_isles24_download",

--- a/src/bids_hub/validation/aomic.py
+++ b/src/bids_hub/validation/aomic.py
@@ -1,0 +1,78 @@
+"""AOMIC dataset validation.
+
+Uses the generic validation framework with AOMIC-specific configuration.
+
+This module contains validation configs for AOMIC datasets:
+- AOMIC-PIOP1 (ds002785): 216 subjects, multimodal MRI
+- (Future) AOMIC-PIOP2 (ds002790): 226 subjects
+- (Future) AOMIC-ID1000 (ds003097): 928 subjects
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import (
+    DatasetValidationConfig,
+    ValidationResult,
+    validate_dataset,
+)
+
+# Expected counts from Scientific Data paper (Snoek et al., 2021)
+# doi:10.1038/s41597-021-00870-6
+# Originally 248 subjects recorded, 216 included after QC
+AOMIC_PIOP1_VALIDATION_CONFIG = DatasetValidationConfig(
+    name="aomic-piop1",
+    expected_counts={
+        "subjects": 216,
+        "t1w": 216,  # All subjects have T1w
+        "dwi": 216,  # All subjects have DWI
+        "bold": 216,  # All subjects have BOLD (rest + tasks)
+    },
+    required_files=[
+        "dataset_description.json",
+        "participants.tsv",
+        "participants.json",
+    ],
+    modality_patterns={
+        "t1w": "*_T1w.nii.gz",
+        "dwi": "*_dwi.nii.gz",
+        "bold": "*_bold.nii.gz",
+    },
+    custom_checks=[],  # AOMIC-PIOP1 doesn't need custom checks beyond generic
+)
+
+
+def validate_aomic_piop1_download(
+    bids_root: Path,
+    run_bids_validator: bool = False,
+    nifti_sample_size: int = 10,
+    tolerance: float = 0.0,
+) -> ValidationResult:
+    """
+    Validate an AOMIC-PIOP1 dataset download.
+
+    This function checks:
+    1. Zero-byte file detection (fast corruption check)
+    2. Required BIDS files exist
+    3. Subject count matches expected (216)
+    4. Modality counts match expected (T1w, DWI, BOLD)
+    5. Sample NIfTI files are loadable
+    6. (Optional) BIDS validator passes
+
+    Args:
+        bids_root: Path to the AOMIC-PIOP1 BIDS dataset root.
+        run_bids_validator: If True, run external BIDS validator (slow).
+        nifti_sample_size: Number of NIfTI files to spot-check.
+        tolerance: Allowed missing fraction (0.0 to 1.0). Default 0.0 (strict).
+
+    Returns:
+        ValidationResult with all check outcomes.
+    """
+    return validate_dataset(
+        bids_root,
+        AOMIC_PIOP1_VALIDATION_CONFIG,
+        run_bids_validator=run_bids_validator,
+        nifti_sample_size=nifti_sample_size,
+        tolerance=tolerance,
+    )

--- a/tests/test_aomic_piop1.py
+++ b/tests/test_aomic_piop1.py
@@ -1,0 +1,319 @@
+"""
+Tests for AOMIC-PIOP1 (Amsterdam Open MRI Collection - PIOP1) dataset module.
+
+These tests use synthetic BIDS structures to verify the AOMIC-PIOP1 file-table builder
+and HF Dataset conversion work correctly.
+"""
+
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+import pandas as pd
+import pytest
+
+from bids_hub import (
+    build_and_push_aomic_piop1,
+    build_aomic_piop1_file_table,
+    get_aomic_piop1_features,
+)
+from bids_hub.core import DatasetBuilderConfig
+
+
+def _create_minimal_nifti(path: Path) -> None:
+    """Create a minimal valid NIfTI file at the given path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = np.ones((2, 2, 2), dtype=np.float32)
+    img = nib.Nifti1Image(data, np.eye(4))
+    nib.save(img, path)
+
+
+@pytest.fixture
+def synthetic_aomic_piop1_bids_root() -> Generator[Path, None, None]:
+    """Create a synthetic BIDS dataset for AOMIC-PIOP1 testing.
+
+    Structure (no sessions, cross-sectional):
+        ds002785/
+        ├── participants.tsv
+        ├── sub-0001/
+        │   ├── anat/
+        │   │   └── sub-0001_T1w.nii.gz
+        │   ├── dwi/
+        │   │   ├── sub-0001_run-1_dwi.nii.gz
+        │   │   └── sub-0001_run-2_dwi.nii.gz
+        │   └── func/
+        │       ├── sub-0001_task-restingstate_bold.nii.gz
+        │       └── sub-0001_task-stopsignal_bold.nii.gz
+        ├── sub-0002/
+        │   └── anat/
+        │       └── sub-0002_T1w.nii.gz  (minimal - only T1w)
+        └── sub-0003: no imaging data (only in participants.tsv)
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir) / "ds002785"
+        root.mkdir()
+
+        # Create participants.tsv
+        participants = pd.DataFrame(
+            {
+                "participant_id": ["sub-0001", "sub-0002", "sub-0003"],
+                "age": [25.0, 30.0, 28.0],
+                "sex": ["F", "M", "F"],
+                "handedness": ["R", "R", "L"],
+            }
+        )
+        participants.to_csv(root / "participants.tsv", sep="\t", index=False)
+
+        # sub-0001: FULL modalities (anat + dwi + func) with MULTIPLE RUNS
+        _create_minimal_nifti(root / "sub-0001" / "anat" / "sub-0001_T1w.nii.gz")
+        # Multiple DWI runs
+        _create_minimal_nifti(root / "sub-0001" / "dwi" / "sub-0001_run-1_dwi.nii.gz")
+        _create_minimal_nifti(root / "sub-0001" / "dwi" / "sub-0001_run-2_dwi.nii.gz")
+        # Multiple BOLD tasks
+        _create_minimal_nifti(root / "sub-0001" / "func" / "sub-0001_task-restingstate_bold.nii.gz")
+        _create_minimal_nifti(root / "sub-0001" / "func" / "sub-0001_task-stopsignal_bold.nii.gz")
+
+        # sub-0002: has T1w only (minimal)
+        _create_minimal_nifti(root / "sub-0002" / "anat" / "sub-0002_T1w.nii.gz")
+
+        # sub-0003: no imaging data at all (only in participants.tsv)
+
+        yield root
+
+
+class TestBuildAomicPiop1FileTable:
+    """Tests for build_aomic_piop1_file_table function."""
+
+    def test_build_file_table_returns_dataframe(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that build_aomic_piop1_file_table returns a DataFrame."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        assert isinstance(df, pd.DataFrame)
+
+    def test_build_file_table_has_correct_columns(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that the DataFrame has all expected columns."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        expected_columns = {
+            "subject_id",
+            "t1w",
+            "dwi",
+            "bold",
+            "age",
+            "sex",
+            "handedness",
+        }
+        assert set(df.columns) == expected_columns
+
+    def test_build_file_table_has_correct_row_count(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that DataFrame has one row per SUBJECT with imaging data."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        # sub-0001 has data, sub-0002 has data, sub-0003 has NO data
+        assert len(df) == 2  # 2 subjects with imaging data
+
+    def test_build_file_table_subject_with_all_modalities(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that subject with all modalities has all paths populated."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        # sub-0001 has ALL modalities: T1w, dwi (2 runs), bold (2 tasks)
+        sub1 = df[df["subject_id"] == "sub-0001"].iloc[0]
+
+        # Structural: single path (string)
+        assert sub1["t1w"] is not None
+        assert isinstance(sub1["t1w"], str)
+
+        # Diffusion: list of paths (multi-run support)
+        assert isinstance(sub1["dwi"], list)
+        assert len(sub1["dwi"]) == 2  # 2 DWI runs
+
+        # BOLD: list of paths (multi-task support)
+        assert isinstance(sub1["bold"], list)
+        assert len(sub1["bold"]) == 2  # 2 BOLD tasks
+
+        # Metadata
+        assert sub1["age"] == 25.0
+        assert sub1["sex"] == "F"
+        assert sub1["handedness"] == "R"
+
+    def test_build_file_table_subject_partial_modalities(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that subject with partial modalities has empty lists for missing."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        # sub-0002 has only T1w (no dwi, no bold)
+        sub2 = df[df["subject_id"] == "sub-0002"].iloc[0]
+
+        assert sub2["t1w"] is not None
+        assert isinstance(sub2["t1w"], str)
+        assert sub2["dwi"] == []  # No dwi/ directory
+        assert sub2["bold"] == []  # No func/ directory
+
+    def test_build_file_table_multiple_dwi_runs(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that multiple DWI runs are captured as list."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        sub1 = df[df["subject_id"] == "sub-0001"].iloc[0]
+
+        assert isinstance(sub1["dwi"], list)
+        assert len(sub1["dwi"]) == 2
+        # All should be strings
+        assert all(isinstance(p, str) for p in sub1["dwi"])
+
+    def test_build_file_table_multiple_bold_runs(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that multiple BOLD tasks are captured as list."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        sub1 = df[df["subject_id"] == "sub-0001"].iloc[0]
+
+        assert isinstance(sub1["bold"], list)
+        assert len(sub1["bold"]) == 2
+        # All should be strings
+        assert all(isinstance(p, str) for p in sub1["bold"])
+
+    def test_build_file_table_missing_subject_excluded(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that subjects with no imaging data are excluded."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        # sub-0003 has no imaging data, should not appear
+        sub3_rows = df[df["subject_id"] == "sub-0003"]
+        assert len(sub3_rows) == 0
+
+    def test_build_file_table_paths_are_strings(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that t1w column contains strings (not Path objects)."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        sub1 = df[df["subject_id"] == "sub-0001"].iloc[0]
+
+        assert isinstance(sub1["t1w"], str)
+
+    def test_build_file_table_metadata_extracted(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that metadata is correctly extracted from participants.tsv."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        sub1 = df[df["subject_id"] == "sub-0001"].iloc[0]
+        sub2 = df[df["subject_id"] == "sub-0002"].iloc[0]
+
+        # sub-0001 metadata
+        assert sub1["age"] == 25.0
+        assert sub1["sex"] == "F"
+        assert sub1["handedness"] == "R"
+
+        # sub-0002 metadata
+        assert sub2["age"] == 30.0
+        assert sub2["sex"] == "M"
+        assert sub2["handedness"] == "R"
+
+    def test_build_file_table_missing_participants_raises(self, tmp_path: Path) -> None:
+        """Test that missing participants.tsv raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError, match=r"participants\.tsv"):
+            build_aomic_piop1_file_table(tmp_path)
+
+    def test_build_file_table_nonexistent_root_raises(self) -> None:
+        """Test that non-existent BIDS root raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError, match="BIDS root not found"):
+            build_aomic_piop1_file_table(Path("/nonexistent/path"))
+
+    def test_build_file_table_empty_lists_for_missing_sequences(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that missing sequences result in empty lists (not None)."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        sub2 = df[df["subject_id"] == "sub-0002"].iloc[0]
+
+        assert sub2["dwi"] == []  # Empty list, not None
+        assert sub2["bold"] == []  # Empty list, not None
+        assert isinstance(sub2["dwi"], list)
+        assert isinstance(sub2["bold"], list)
+
+    def test_build_file_table_paths_are_absolute(
+        self, synthetic_aomic_piop1_bids_root: Path
+    ) -> None:
+        """Test that file paths are absolute."""
+        df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
+        sub1 = df[df["subject_id"] == "sub-0001"].iloc[0]
+
+        # Wrap strings in Path() to check absolute
+        assert Path(sub1["t1w"]).is_absolute()
+        # Check DWI paths
+        assert all(Path(p).is_absolute() for p in sub1["dwi"])
+
+
+class TestGetAomicPiop1Features:
+    """Tests for get_aomic_piop1_features function."""
+
+    def test_get_features_returns_features(self) -> None:
+        """Test that get_aomic_piop1_features returns a Features object."""
+        from datasets import Features
+
+        features = get_aomic_piop1_features()
+        assert isinstance(features, Features)
+
+    def test_get_features_has_nifti_columns(self) -> None:
+        """Test that Nifti columns are present with correct types."""
+        from datasets import Nifti, Sequence
+
+        features = get_aomic_piop1_features()
+
+        # Structural: single file per subject
+        assert isinstance(features["t1w"], Nifti)
+        # Functional/Diffusion: multiple runs per subject (Sequence of Nifti)
+        assert isinstance(features["dwi"], Sequence)
+        assert isinstance(features["bold"], Sequence)
+
+    def test_get_features_has_metadata_columns(self) -> None:
+        """Test that metadata columns are present."""
+        features = get_aomic_piop1_features()
+
+        assert "subject_id" in features
+        assert "age" in features
+        assert "sex" in features
+        assert "handedness" in features
+
+
+class TestBuildAndPushAomicPiop1:
+    """Tests for build_and_push_aomic_piop1 integration."""
+
+    def test_dry_run_calls_build_hf_dataset(self, synthetic_aomic_piop1_bids_root: Path) -> None:
+        """Test that dry run calls build_hf_dataset with correct arguments."""
+        from unittest.mock import patch
+
+        config = DatasetBuilderConfig(
+            bids_root=synthetic_aomic_piop1_bids_root,
+            hf_repo_id="test/test-repo",
+            dry_run=True,
+        )
+
+        with patch("bids_hub.datasets.aomic_piop1.build_hf_dataset") as mock_build:
+            mock_build.return_value = None
+            build_and_push_aomic_piop1(config)
+            mock_build.assert_called_once()
+
+    def test_dry_run_does_not_push(self, synthetic_aomic_piop1_bids_root: Path) -> None:
+        """Test that dry run does not call push_dataset_to_hub."""
+        from unittest.mock import MagicMock, patch
+
+        config = DatasetBuilderConfig(
+            bids_root=synthetic_aomic_piop1_bids_root,
+            hf_repo_id="test/test-repo",
+            dry_run=True,
+        )
+
+        with (
+            patch("bids_hub.datasets.aomic_piop1.build_hf_dataset") as mock_build,
+            patch("bids_hub.datasets.aomic_piop1.push_dataset_to_hub") as mock_push,
+        ):
+            mock_build.return_value = MagicMock()
+            build_and_push_aomic_piop1(config)
+            mock_push.assert_not_called()


### PR DESCRIPTION
## Description

Add support for AOMIC-PIOP1 dataset (OpenNeuro ds002785) with 216 healthy adult subjects.

Implements Issue #12.

## Changes

**Core Implementation:**
- `src/bids_hub/datasets/aomic_piop1.py` - Dataset module with T1w, DWI, BOLD support
- `src/bids_hub/validation/aomic.py` - Validation config (expected counts from Scientific Data paper)
- CLI commands: `bids-hub aomic piop1 [build|validate|info]`

**Testing:**
- `tests/test_aomic_piop1.py` - 19 tests with 93% module coverage
- Synthetic BIDS fixture with 3 test subjects (full/minimal/missing)
- Improved type checking practices (explicit string vs Path assertions)

**Documentation:**
- `docs/dataset-cards/aomic-piop1.md` - Complete dataset card
- `scripts/download_aomic_piop1.sh` - Download script with 3 methods
- Updated `CLAUDE.md` with AOMIC-PIOP1 commands and schema

**Integration:**
- Updated exports in `__init__.py` files
- Added `coverage.xml` to `.gitignore`

## Dataset Details

- **Source:** [OpenNeuro ds002785](https://openneuro.org/datasets/ds002785)
- **Paper:** [Snoek et al., Scientific Data 2021](https://doi.org/10.1038/s41597-021-00870-6)
- **License:** CC0 (Public Domain)
- **Subjects:** 216 healthy adults (after QC)
- **Modalities:** T1w (single), DWI (multiple runs), BOLD (resting-state + tasks)

## Testing

- ✅ All 97 tests pass (78 existing + 19 new)
- ✅ Type checking: 0 errors (mypy strict)
- ✅ Linting: 0 errors (ruff)
- ✅ Formatting: All files formatted
- ✅ `make all` passes

Closes #12